### PR TITLE
Include tufte-remark files in plugin

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Jeff Rafter
+Copyright (c) 2017 Jan Florian Dietrich (tufte-remark)
+
+Copyright (c) 2020 Jeff Rafter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ plugins: [
   {
     resolve: `gatsby-transformer-remark`,
     options: {
-      plugins: [`gatsby-remark-tufte`]
-    }
-  }
+      plugins: [`gatsby-remark-tufte`],
+    },
+  },
 ];
 ```

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const sidenotes = require("@tufte-markdown/remark-sidenotes")();
-const wrapInSection = require("@tufte-markdown/remark-wrap-in-section")();
-const tufteFigureTransformer = require("@tufte-markdown/remark-figure-transformer")();
-const tufteFigureParser = require("@tufte-markdown/remark-figure-parser");
+const sidenotes = require("./src/remark-sidenotes-transformer")();
+const wrapInSection = require("./src/wrap-in-section-transformer")();
+const tufteFigureTransformer = require("./src/remark-figure-transformer")();
+const tufteFigureParser = require("./src/remark-figure-transformer");
 
 module.exports = ({ markdownAST }, pluginOptions = {}) => {
   try {
@@ -17,6 +17,6 @@ module.exports = ({ markdownAST }, pluginOptions = {}) => {
   return markdownAST;
 };
 
-module.exports.setParserPlugins = options => {
+module.exports.setParserPlugins = (options) => {
   return [[tufteFigureParser]];
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const sidenotes = require("./src/remark-sidenotes-transformer")();
 const wrapInSection = require("./src/wrap-in-section-transformer")();
 const tufteFigureTransformer = require("./src/remark-figure-transformer")();
-const tufteFigureParser = require("./src/remark-figure-transformer");
+const tufteFigureParser = require("./src/remark-figure-parser");
 
 module.exports = ({ markdownAST }, pluginOptions = {}) => {
   try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-remark-tufte",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -204,49 +204,17 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@tufte-markdown/remark-figure-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tufte-markdown/remark-figure-parser/-/remark-figure-parser-1.0.0.tgz",
-      "integrity": "sha512-zLLDK00ftt/j7KDqSFSwrTU862i4PU7mI4ZUZlEpyU+rFGT82RO5pS8dJCYFYEMaf/h1p+T7dkowQpmGCpgZFQ==",
-      "requires": {
-        "remark-parse": "^4.0.0",
-        "unified": "^6.1.6"
-      }
-    },
-    "@tufte-markdown/remark-figure-transformer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tufte-markdown/remark-figure-transformer/-/remark-figure-transformer-1.0.0.tgz",
-      "integrity": "sha512-qb2rpsoR8+zvfF+ZgS0pc0SKo7h62MCm/OPUqRWjDMTAu6sDAoGbR2uN7pFTCYBpQaRR4KSMniuV3ELN0pg0rQ==",
-      "requires": {
-        "html-parse-stringify": "^1.0.2",
-        "unist-util-visit": "^1.2.0"
-      }
-    },
-    "@tufte-markdown/remark-sidenotes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tufte-markdown/remark-sidenotes/-/remark-sidenotes-1.0.0.tgz",
-      "integrity": "sha512-Ggb+sGCKQxbxPkNHqs6TZm70FQ92fNJPXFP/cG39TPbSctnpySFaVP4cIoS5nh+Ts55iaS61Uf6hcZgob9nrAQ==",
-      "requires": {
-        "hast-util-to-html": "^3.1.0",
-        "mdast-util-to-hast": "^2.5.0",
-        "unist-util-select": "^1.5.0",
-        "unist-util-visit": "^1.2.0"
-      }
-    },
-    "@tufte-markdown/remark-wrap-in-section": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tufte-markdown/remark-wrap-in-section/-/remark-wrap-in-section-2.0.1.tgz",
-      "integrity": "sha512-8iOQhm2uSnlFuywtY1gMsrMSH+6taGH0HpPRtSLQY2K414pLAIKhAFYDhbJ3BxF1uK9d/Sg8bSl5KgSUHaJ3yw==",
-      "requires": {
-        "unist-util-visit": "^1.2.0"
-      }
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -362,9 +330,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "bail": {
       "version": "1.0.3",
@@ -452,6 +420,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -498,6 +476,11 @@
         }
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -527,9 +510,9 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "ccount": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
-      "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -543,24 +526,24 @@
       }
     },
     "character-entities": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
-      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
     },
     "character-entities-html4": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
-      "integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g=="
     },
     "character-entities-legacy": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
-      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
     },
     "character-reference-invalid": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
-      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
     "chokidar": {
       "version": "2.1.8",
@@ -609,9 +592,9 @@
       }
     },
     "collapse-white-space": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
-      "integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -648,9 +631,9 @@
       }
     },
     "comma-separated-tokens": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz",
-      "integrity": "sha512-Jrx3xsP4pPv4AwJUDWY9wOXGtwPXARej6Xd99h4TUGotmf8APuquKMpK+dnD3UgyxK7OEWaisjZz+3b5jtL6xQ=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
     },
     "commander": {
       "version": "2.20.0",
@@ -804,9 +787,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detab": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.2.tgz",
-      "integrity": "sha512-Q57yPrxScy816TTE1P/uLRXLDKjXhvYTbfxS/e6lPD+YrqghbsMlGB9nQzj/zVtSPaF0DFPSdO916EWO4sQUyQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.3.tgz",
+      "integrity": "sha512-Up8P0clUVwq0FnFjDclzZsy9PadzRn5FFxrr47tQQvMHqyiFYVbpH8oXDzWtF0Q7pYy3l+RPmtBl+BsFF6wH0A==",
       "requires": {
         "repeat-string": "^1.5.4"
       }
@@ -975,14 +958,14 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       }
     },
     "extsprintf": {
@@ -991,22 +974,29 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -1088,14 +1078,15 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+      "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
       "dev": true,
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -1143,7 +1134,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1173,7 +1164,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1200,12 +1191,12 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -1231,7 +1222,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1260,7 +1251,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1279,7 +1270,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1315,13 +1306,13 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.5",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1331,42 +1322,42 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1380,11 +1371,11 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1394,19 +1385,29 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npmlog": {
@@ -1471,7 +1472,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1486,18 +1487,10 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "2.3.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1512,7 +1505,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1539,7 +1532,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1592,18 +1585,18 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -1628,7 +1621,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1763,39 +1756,31 @@
       }
     },
     "hast-util-is-element": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.3.tgz",
-      "integrity": "sha512-C62CVn7jbjp89yOhhy7vrkSaB7Vk906Gtcw/Ihd+Iufnq+2pwOZjdPmpzpKLWJXPJBMDX3wXg4FqmdOayPcewA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.4.tgz",
+      "integrity": "sha512-NFR6ljJRvDcyPP5SbV7MyPBgF47X3BsskLnmw1U34yL+X6YC0MoBx9EyMg8Jtx4FzGH95jw8+c1VPLHaRA0wDQ=="
     },
     "hast-util-to-html": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-3.1.0.tgz",
-      "integrity": "sha1-iCyZhJ5AEw6ZHAQuRW1FPZXDbP8=",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-7.1.0.tgz",
+      "integrity": "sha512-RjvNL41bYnxTOA+s8W8mjhVxH1J0dXza9hlakVHbghFsfj3JO/lsq3DsR/Md2HbynS8y89/LA7k0lhtnYJ1Yzw==",
       "requires": {
         "ccount": "^1.0.0",
-        "comma-separated-tokens": "^1.0.1",
+        "comma-separated-tokens": "^1.0.0",
         "hast-util-is-element": "^1.0.0",
         "hast-util-whitespace": "^1.0.0",
         "html-void-elements": "^1.0.0",
-        "kebab-case": "^1.0.0",
-        "property-information": "^3.1.0",
+        "property-information": "^5.0.0",
         "space-separated-tokens": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unist-util-is": "^2.0.0",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-          "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
-        }
+        "stringify-entities": "^3.0.0",
+        "unist-util-is": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "hast-util-whitespace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.3.tgz",
-      "integrity": "sha512-AlkYiLTTwPOyxZ8axq2/bCwRUPjIPBfrHkXuCR92B38b3lSdU22R5F/Z4DL6a2kxWpekWq1w6Nj48tWat6GeRA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
+      "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A=="
     },
     "html-parse-stringify": {
       "version": "1.0.3",
@@ -1807,9 +1792,9 @@
       }
     },
     "html-void-elements": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.4.tgz",
-      "integrity": "sha512-yMk3naGPLrfvUV9TdDbuYXngh/TpHbA6TrOw3HL9kS8yhwx7i309BReNg7CbAJXGE+UMJ6je5OqJ7lC63o6YuQ=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
+      "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -1859,14 +1844,14 @@
       }
     },
     "is-alphabetical": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
     },
     "is-alphanumerical": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
       "requires": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
@@ -1910,9 +1895,9 @@
       }
     },
     "is-decimal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
-      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -1960,9 +1945,9 @@
       }
     },
     "is-hexadecimal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
     "is-number": {
       "version": "3.0.0",
@@ -2012,9 +1997,9 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-whitespace-character": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
-      "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -2024,9 +2009,9 @@
       "optional": true
     },
     "is-word-character": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
-      "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -2092,9 +2077,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -2118,20 +2103,15 @@
         "verror": "1.10.0"
       }
     },
-    "kebab-case": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.0.tgz",
-      "integrity": "sha1-P55JkK3K0MaGwOcB92RYaPdfkes="
-    },
     "kew": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
       "optional": true
     },
@@ -2167,34 +2147,32 @@
       }
     },
     "markdown-escapes": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
-      "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
     },
     "mdast-util-definitions": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.4.tgz",
-      "integrity": "sha512-HfUArPog1j4Z78Xlzy9Q4aHLnrF/7fb57cooTHypyGoe2XFNbcx/kWZDoOz+ra8CkUzvg3+VHV434yqEd1DRmA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-2.0.1.tgz",
+      "integrity": "sha512-Co+DQ6oZlUzvUR7JCpP249PcexxygiaKk9axJh+eRzHDZJk2julbIdKB4PXHVxdBuLzvJ1Izb+YDpj2deGMOuA==",
       "requires": {
-        "unist-util-visit": "^1.0.0"
+        "unist-util-visit": "^2.0.0"
       }
     },
     "mdast-util-to-hast": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-2.5.0.tgz",
-      "integrity": "sha1-8IeETSVcdUDzaQbaMLoQbA7l7i8=",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-8.2.0.tgz",
+      "integrity": "sha512-WjH/KXtqU66XyTJQ7tg7sjvTw1OQcVV0hKdFh3BgHPwZ96fSBCQ/NitEHsN70Mmnggt+5eUUC7pCnK+2qGQnCA==",
       "requires": {
         "collapse-white-space": "^1.0.0",
         "detab": "^2.0.0",
-        "mdast-util-definitions": "^1.2.0",
-        "mdurl": "^1.0.1",
-        "trim": "0.0.1",
+        "mdast-util-definitions": "^2.0.0",
+        "mdurl": "^1.0.0",
         "trim-lines": "^1.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-generated": "^1.1.0",
+        "unist-builder": "^2.0.0",
+        "unist-util-generated": "^1.0.0",
         "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.0",
-        "xtend": "^4.0.1"
+        "unist-util-visit": "^2.0.0"
       }
     },
     "mdurl": {
@@ -2225,16 +2203,16 @@
       }
     },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.43.0"
       }
     },
     "minimatch": {
@@ -2247,9 +2225,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -2275,11 +2253,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -2332,6 +2310,11 @@
       "dev": true,
       "optional": true
     },
+    "not": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/not/-/not-0.1.0.tgz",
+      "integrity": "sha1-yWkcF0bFXc++VMvYvU/wQbwrUZ0="
+    },
     "nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -2344,11 +2327,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -2425,9 +2403,9 @@
       }
     },
     "parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
       "requires": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -2536,14 +2514,17 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
     },
     "property-information": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-3.2.0.tgz",
-      "integrity": "sha1-/RSDyPusYYCPX+NZ52k6H0ilgzE="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.4.0.tgz",
+      "integrity": "sha512-nmMWAm/3vKFGmmOWOcdLjgq/Hlxa+hsuR/px1Lp/UGEyc5A22A6l78Shc2C0E71sPmAqglni+HrS7L7VJ7AUCA==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "psl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -2598,24 +2579,25 @@
       }
     },
     "remark-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
-      "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.0.tgz",
+      "integrity": "sha512-Ck14G1Ns/GEPXhSw6m1Uv28kMtVk63e59NyL+QlhBBwBdIUXROM6MPfBehPhW6TW2d73batMdZsKwuxl5i3tEA==",
       "requires": {
+        "ccount": "^1.0.0",
         "collapse-white-space": "^1.0.2",
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0",
         "is-whitespace-character": "^1.0.0",
         "is-word-character": "^1.0.0",
         "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.0.2",
+        "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
         "trim": "0.0.1",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
+        "unist-util-remove-position": "^2.0.0",
+        "vfile-location": "^3.0.0",
         "xtend": "^4.0.1"
       }
     },
@@ -2644,9 +2626,9 @@
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -2655,7 +2637,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -2665,7 +2647,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       }
@@ -2945,9 +2927,15 @@
       "optional": true
     },
     "space-separated-tokens": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",
-      "integrity": "sha512-UyhMSmeIqZrQn2UdjYpxEkwY9JUrn8pP+7L4f91zRzOQuI8MF1FGLfYU9DKCYeLdo7LXMxwrX5zKFy7eeeVHuA=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
+    },
+    "speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true
     },
     "split-string": {
       "version": "3.1.0",
@@ -2976,9 +2964,9 @@
       }
     },
     "state-toggle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
-      "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -3012,13 +3000,14 @@
       }
     },
     "stringify-entities": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
-      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.0.tgz",
+      "integrity": "sha512-h7NJJIssprqlyjHT2eQt2W1F+MCcNmwPGlKb0bWEdET/3N44QN3QbUF/ueKCgAssyKRZ3Br9rQ7FcXjHr0qLHw==",
       "requires": {
         "character-entities-html4": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
         "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.2",
         "is-hexadecimal": "^1.0.0"
       }
     },
@@ -3089,19 +3078,12 @@
       }
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "trim": {
@@ -3110,9 +3092,9 @@
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-lines": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.2.tgz",
-      "integrity": "sha512-3GOuyNeTqk3FAqc3jOJtw7FTjYl94XBR5aD9QnDbK/T4CA9sW/J0l9RoaRPE9wyPP7NF331qnHnvJFBJ+IDkmQ=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
+      "integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA=="
     },
     "trim-right": {
       "version": "1.0.1",
@@ -3121,9 +3103,9 @@
       "dev": true
     },
     "trim-trailing-lines": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
-      "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
     },
     "trough": {
       "version": "1.0.3",
@@ -3184,22 +3166,19 @@
       }
     },
     "unist-builder": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
-      "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
-      "requires": {
-        "object-assign": "^4.1.0"
-      }
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
+      "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw=="
     },
     "unist-util-generated": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.4.tgz",
-      "integrity": "sha512-SA7Sys3h3X4AlVnxHdvN/qYdr4R38HzihoEVY2Q2BZu8NHWDnw5OGcC/tXWjQfd4iG+M6qRFNIRGqJmp2ez4Ww=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.5.tgz",
+      "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw=="
     },
     "unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
+      "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
     },
     "unist-util-modify-children": {
       "version": "1.1.4",
@@ -3210,26 +3189,28 @@
       }
     },
     "unist-util-position": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.3.tgz",
-      "integrity": "sha512-28EpCBYFvnMeq9y/4w6pbnFmCUfzlsc41NJui5c51hOFjBA1fejcwc+5W4z2+0ECVbScG3dURS3JTVqwenzqZw=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
+      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
     },
     "unist-util-remove-position": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
-      "integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
+      "integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
       "requires": {
-        "unist-util-visit": "^1.1.0"
+        "unist-util-visit": "^2.0.0"
       }
     },
     "unist-util-select": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-1.5.0.tgz",
-      "integrity": "sha1-qTwr6MD2U4J4A7gTMa3sKqJM2TM=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-3.0.1.tgz",
+      "integrity": "sha512-VQpTuqZVJlRbosQdnLdTPIIqwZeU70YZ5aMBOqtFNGeeCdYn6ORZt/9RiaVlbl06ocuf58SVMoFa7a13CSGPMA==",
       "requires": {
-        "css-selector-parser": "^1.1.0",
-        "debug": "^2.2.0",
-        "nth-check": "^1.0.1"
+        "css-selector-parser": "^1.0.0",
+        "not": "^0.1.0",
+        "nth-check": "^1.0.0",
+        "unist-util-is": "^4.0.0",
+        "zwitch": "^1.0.0"
       }
     },
     "unist-util-stringify-position": {
@@ -3238,11 +3219,13 @@
       "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
     },
     "unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
+      "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
       "requires": {
-        "unist-util-visit-parents": "^2.0.0"
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
       }
     },
     "unist-util-visit-children": {
@@ -3251,11 +3234,12 @@
       "integrity": "sha512-/GQ8KNRrG+qD30H76FZNc6Ok+8XTu8lxJByN5LnQ4eQfqxda2gP0CPsCX63BRB26ZRMNf6i1c+jlvNlqysEoFg=="
     },
     "unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
+      "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
       "requires": {
-        "unist-util-is": "^3.0.0"
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
       }
     },
     "unset-value": {
@@ -3337,9 +3321,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "verror": {
       "version": "1.10.0",
@@ -3363,9 +3347,9 @@
       }
     },
     "vfile-location": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
-      "integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.0.1.tgz",
+      "integrity": "sha512-yYBO06eeN/Ki6Kh1QAkgzYpWT1d3Qln+ZCtSbJqFExPl1S3y2qqotJQXoh6qEvl/jDlgpUJolBn3PItVnnZRqQ=="
     },
     "vfile-message": {
       "version": "1.1.1",
@@ -3405,12 +3389,18 @@
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
+    },
+    "zwitch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,18 +8,22 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@tufte-markdown/remark-figure-parser": "^1.0.0",
-    "@tufte-markdown/remark-figure-transformer": "^1.0.0",
-    "@tufte-markdown/remark-sidenotes": "^1.0.0",
-    "@tufte-markdown/remark-wrap-in-section": "^2.0.1",
-    "retext": "^5.0.0"
+    "hast-util-to-html": "^7.1.0",
+    "html-parse-stringify": "^1.0.3",
+    "mdast-util-to-hast": "^8.2.0",
+    "remark-parse": "^8.0.0",
+    "retext": "^5.0.0",
+    "unist-util-select": "^3.0.1",
+    "unist-util-visit": "^2.0.2"
   },
   "deprecated": false,
   "description": "Enable sidenotes and margin notes for your markdown",
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "cross-env": "^5.1.4"
+    "cross-env": "^5.1.4",
+    "speakingurl": "^14.0.1",
+    "unist-builder": "^2.0.3"
   },
   "keywords": [
     "gatsby",

--- a/package.json
+++ b/package.json
@@ -8,15 +8,16 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "hast-util-to-html": "^7.1.0",
     "html-parse-stringify": "^1.0.3",
-    "mdast-util-to-hast": "^8.2.0",
-    "remark-parse": "^8.0.0",
+    "remark-parse": "^4.0.0",
+    "unified": "^6.1.6",
     "retext": "^5.0.0",
-    "unist-util-select": "^1.5.0",
-    "unist-util-visit": "^2.0.2",
     "speakingurl": "^14.0.1",
-    "unist-builder": "^2.0.3"
+    "unist-builder": "^1.0.2",
+    "hast-util-to-html": "^3.1.0",
+    "mdast-util-to-hast": "^2.5.0",
+    "unist-util-select": "^1.5.0",
+    "unist-util-visit": "^1.2.0"
   },
   "deprecated": false,
   "description": "Enable sidenotes and margin notes for your markdown",

--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
     "mdast-util-to-hast": "^8.2.0",
     "remark-parse": "^8.0.0",
     "retext": "^5.0.0",
-    "unist-util-select": "^3.0.1",
-    "unist-util-visit": "^2.0.2"
+    "unist-util-select": "^1.5.0",
+    "unist-util-visit": "^2.0.2",
+    "speakingurl": "^14.0.1",
+    "unist-builder": "^2.0.3"
   },
   "deprecated": false,
   "description": "Enable sidenotes and margin notes for your markdown",
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "cross-env": "^5.1.4",
-    "speakingurl": "^14.0.1",
-    "unist-builder": "^2.0.3"
+    "cross-env": "^5.1.4"
   },
   "keywords": [
     "gatsby",

--- a/src/remark-figure-parser.js
+++ b/src/remark-figure-parser.js
@@ -1,5 +1,5 @@
-import unified from "unified";
-import parser from "remark-parse";
+const unified = require("unified");
+const parser = require("remark-parse");
 
 const FIGURE_OPENING_TAG = "<figure";
 const OPENING_TAG = /<figure([^>]*)>/;
@@ -81,4 +81,4 @@ function isRemarkParser(parser) {
   );
 }
 
-export default tufteFigureParser;
+module.exports = tufteFigureParser;

--- a/src/remark-figure-parser.js
+++ b/src/remark-figure-parser.js
@@ -1,0 +1,84 @@
+import unified from "unified";
+import parser from "remark-parse";
+
+const FIGURE_OPENING_TAG = "<figure";
+const OPENING_TAG = /<figure([^>]*)>/;
+const CLOSING_TAG = "</figure>";
+
+function tufteFigureParser() {
+  var parser = this.Parser;
+
+  if (!isRemarkParser(parser)) {
+    throw new Error("Missing parser, cannot attach `remark-figure`");
+  }
+
+  var proto = parser.prototype;
+  proto.blockTokenizers.tufteFigure = figureTokenizer;
+  proto.blockMethods.splice(
+    proto.blockMethods.indexOf("html"),
+    0,
+    "tufteFigure"
+  );
+
+  function locator(value, fromIndex) {
+    const assertOpeningTag = value.match(OPENING_TAG);
+    if (!assertOpeningTag) return;
+
+    const openingTag = assertOpeningTag[0];
+    return value.indexOf(openingTag, fromIndex);
+  }
+
+  function figureTokenizer(eat, value, silent) {
+    if (!value.startsWith(FIGURE_OPENING_TAG)) return;
+
+    const openingTagMatches = value.match(OPENING_TAG);
+    const openingTag = openingTagMatches[0];
+    const endTagPosition = value.indexOf(CLOSING_TAG, openingTagMatches.index);
+    if (endTagPosition === -1) return;
+
+    const endPosition = endTagPosition + CLOSING_TAG.length;
+    const figureBlock = value.slice(0, endPosition);
+    const children = parseMarkdown(
+      value.slice(openingTagMatches.index + openingTag.length, endTagPosition)
+    );
+
+    /* Exit with true in silent mode after successful parse - never used (yet) */
+    if (silent) {
+      return true;
+    }
+
+    return eat(figureBlock)({
+      type: "tufteFigure",
+      attributes: {
+        openingHtml: openingTag,
+        closingHtml: CLOSING_TAG,
+      },
+      children,
+    });
+  }
+  figureTokenizer.locator = locator;
+}
+
+function parseMarkdown(markdown) {
+  const result = unified()
+    .use(parser, { commonmark: true, footnotes: true })
+    .parse(markdown);
+
+  if (result.type === "root" && result.children[0].type === "paragraph") {
+    return result.children[0].children;
+  }
+
+  return result;
+}
+
+function isRemarkParser(parser) {
+  return Boolean(
+    parser &&
+      parser.prototype &&
+      parser.prototype.inlineTokenizers &&
+      parser.prototype.inlineTokenizers.break &&
+      parser.prototype.inlineTokenizers.break.locator
+  );
+}
+
+export default tufteFigureParser;

--- a/src/remark-figure-transformer.js
+++ b/src/remark-figure-transformer.js
@@ -1,0 +1,37 @@
+import visit from "unist-util-visit";
+import HTML from "html-parse-stringify";
+
+function tufteFigureTransformer() {
+  return transformer;
+}
+
+export function transformer(tree) {
+  visit(tree, "tufteFigure", (node, index, parent) => {
+    const openTagAst = HTML.parse(node.attributes.openingHtml);
+
+    let figureProperties;
+
+    if (openTagAst) {
+      if (openTagAst[0].attrs.class) {
+        figureProperties = {
+          className: openTagAst[0].attrs.class,
+        };
+      }
+    }
+
+    const replacement = {
+      type: "paragraph",
+      children: node.children,
+      data: {
+        hName: "figure",
+        hProperties: figureProperties,
+      },
+    };
+    parent.children.splice(index, 1, replacement);
+  });
+
+  // only for test
+  return tree;
+}
+
+export default tufteFigureTransformer;

--- a/src/remark-figure-transformer.js
+++ b/src/remark-figure-transformer.js
@@ -1,11 +1,11 @@
-import visit from "unist-util-visit";
-import HTML from "html-parse-stringify";
+const visit = require("unist-util-visit");
+const HTML = require("html-parse-stringify");
 
 function tufteFigureTransformer() {
   return transformer;
 }
 
-export function transformer(tree) {
+function transformer(tree) {
   visit(tree, "tufteFigure", (node, index, parent) => {
     const openTagAst = HTML.parse(node.attributes.openingHtml);
 
@@ -34,4 +34,4 @@ export function transformer(tree) {
   return tree;
 }
 
-export default tufteFigureTransformer;
+module.exports = tufteFigureTransformer;

--- a/src/remark-sidenotes-transformer.js
+++ b/src/remark-sidenotes-transformer.js
@@ -1,0 +1,97 @@
+import getSlug from "speakingurl";
+import visit from "unist-util-visit";
+import select from "unist-util-select";
+import toHAST from "mdast-util-to-hast";
+import toHTML from "hast-util-to-html";
+
+const MARGINNOTE_SYMBOL = "{-}";
+
+function sidenotes() {
+  return transformer;
+}
+
+const generateInputId = (isMarginNote, title) =>
+  `${isMarginNote ? "md" : "sd"}-${getSlug(title, { truncate: 20 })}`;
+
+const getReplacement = ({ isMarginNote, noteHTML }) => {
+  const inputId = generateInputId(isMarginNote, noteHTML);
+  const labelCls = `margin-toggle ${isMarginNote ? "" : "sidenote-number"}`;
+  const labelSymbol = isMarginNote ? "&#8853;" : "";
+  const noteTypeCls = isMarginNote ? "marginnote" : "sidenote";
+
+  return [
+    {
+      type: "html",
+      value: `<label for="${inputId}" class="${labelCls}">${labelSymbol}</label>`,
+    },
+    {
+      type: "html",
+      value: `<input type="checkbox" id="${inputId}" class="margin-toggle" />`,
+    },
+    {
+      type: "html",
+      value: `<span class="${noteTypeCls}">`,
+    },
+    {
+      type: "html",
+      value: noteHTML,
+    },
+    {
+      type: "html",
+      value: "</span>",
+    },
+  ];
+};
+
+const coerceToHtml = (nodeArray) =>
+  nodeArray.map((node) => toHTML(toHAST(node))).join("") || "";
+
+const extractNoteFromHtml = (note) => {
+  const matches = note.match(/(\s+)*({-})*\s*((.|\n)+)/);
+
+  return {
+    isMarginNote: matches[2] === MARGINNOTE_SYMBOL,
+    noteHTML: matches[3],
+  };
+};
+
+export function transformer(tree) {
+  // "Regular" Sidenotes/Marginnotes consisting of a reference and a definition
+  // Syntax for Sidenotes [^<number>] and somewhere else [^<number]: <markdown>
+  // Syntax for Marginnotes [^<descriptor>] and somewhere else [^<descriptor]: {-}
+  visit(tree, "footnoteReference", (node, index, parent) => {
+    const target = select(
+      tree,
+      `footnoteDefinition[identifier=${node.identifier}]`
+    );
+
+    if (!target.length) throw new Error("No coresponding note found");
+
+    const notesAst =
+      target[0].children.length && target[0].children[0].type === "paragraph"
+        ? target[0].children[0].children
+        : target[0].children;
+
+    const nodeDetail = extractNoteFromHtml(coerceToHtml(notesAst));
+
+    parent.children.splice(index, 1, ...getReplacement(nodeDetail));
+  });
+
+  visit(tree, "footnoteDefinition", (node, index, parent) => {
+    parent.children.splice(index, 1);
+  });
+
+  // "Inline" Sidenotes which do not have two parts
+  // Syntax: [^{-} <markdown>]
+  visit(tree, "footnote", (node, index, parent) => {
+    const notesAst = node.children;
+    const nodeDetail = extractNoteFromHtml(coerceToHtml(notesAst));
+
+    parent.children.splice(index, 1, ...getReplacement(nodeDetail));
+  });
+
+  // Only for testing
+  return tree;
+}
+
+export default sidenotes;

--- a/src/remark-sidenotes-transformer.js
+++ b/src/remark-sidenotes-transformer.js
@@ -1,8 +1,8 @@
-import getSlug from "speakingurl";
-import visit from "unist-util-visit";
-import select from "unist-util-select";
-import toHAST from "mdast-util-to-hast";
-import toHTML from "hast-util-to-html";
+const getSlug = require("speakingurl");
+const visit = require("unist-util-visit");
+const select = require("unist-util-select");
+const toHAST = require("mdast-util-to-hast");
+const toHTML = require("hast-util-to-html");
 
 const MARGINNOTE_SYMBOL = "{-}";
 
@@ -55,7 +55,7 @@ const extractNoteFromHtml = (note) => {
   };
 };
 
-export function transformer(tree) {
+function transformer(tree) {
   // "Regular" Sidenotes/Marginnotes consisting of a reference and a definition
   // Syntax for Sidenotes [^<number>] and somewhere else [^<number]: <markdown>
   // Syntax for Marginnotes [^<descriptor>] and somewhere else [^<descriptor]: {-}
@@ -65,7 +65,8 @@ export function transformer(tree) {
       `footnoteDefinition[identifier=${node.identifier}]`
     );
 
-    if (!target.length) throw new Error("No coresponding note found");
+    if (!target.length)
+      throw new Error(`No coresponding note found for "${node.identifier}"`);
 
     const notesAst =
       target[0].children.length && target[0].children[0].type === "paragraph"
@@ -94,4 +95,4 @@ export function transformer(tree) {
   return tree;
 }
 
-export default sidenotes;
+module.exports = sidenotes;

--- a/src/wrap-in-section-transformer.js
+++ b/src/wrap-in-section-transformer.js
@@ -1,10 +1,10 @@
-import visit from "unist-util-visit";
+const visit = require("unist-util-visit");
 
 function wrapInSection() {
   return transformer;
 }
 
-export function transformer(tree) {
+function transformer(tree) {
   const headingsMap = [];
   const newTree = [];
 
@@ -38,4 +38,4 @@ export function transformer(tree) {
   return tree;
 }
 
-export default wrapInSection;
+module.exports = wrapInSection;

--- a/src/wrap-in-section-transformer.js
+++ b/src/wrap-in-section-transformer.js
@@ -1,0 +1,41 @@
+import visit from "unist-util-visit";
+
+function wrapInSection() {
+  return transformer;
+}
+
+export function transformer(tree) {
+  const headingsMap = [];
+  const newTree = [];
+
+  visit(tree, "heading", (node, index) => {
+    if (node.depth === 2) headingsMap.push(index);
+  });
+
+  if (headingsMap.length) {
+    for (let index = 0; index <= headingsMap.length; index++) {
+      const sectionStartIndex = index === 0 ? 0 : headingsMap[index - 1];
+      const sectionEndIndex =
+        index === headingsMap.length
+          ? tree.children.length
+          : headingsMap[index];
+      const children = tree.children.slice(sectionStartIndex, sectionEndIndex);
+
+      if (children.length) {
+        const wrapperNode = {
+          type: "paragraph",
+          children,
+          data: { hName: "section" },
+        };
+
+        newTree.push(wrapperNode);
+      }
+    }
+
+    tree.children = newTree;
+  }
+
+  return tree;
+}
+
+export default wrapInSection;


### PR DESCRIPTION
The tufte-remark plugin had some security vulnerabilities in its dependencies. While trying to upgrade those I struggled to make it work outside of the rollup and browser context. Instead I pulled those files into this plugin directly (and change the imports as needed).

I've also updated the license to include the original copyright for those files.